### PR TITLE
Move device-related logic from client to agent

### DIFF
--- a/src/main/java/com/musala/atmosphere/commons/RoutingAction.java
+++ b/src/main/java/com/musala/atmosphere/commons/RoutingAction.java
@@ -492,7 +492,37 @@ public enum RoutingAction implements Serializable {
     /**
      * Used to paste the text currently in the clipboard into a TextView.
      */
-    IME_PASTE_TEXT;
+    IME_PASTE_TEXT,
+    /**
+     * Invokes the method that executes a tap on the coordinates provided as a {@link Point}.
+     */
+    GESTURE_TAP(new RoutingActionArgumentValidator(Point.class)),
+    /**
+     * Invokes the method that executes a long press on the coordinates provided as a {@link Point}
+     * for the specified interval in milliseconds.
+     */
+    GESTURE_LONG_PRESS(new RoutingActionArgumentValidator(Point.class), new RoutingActionArgumentValidator(Integer.class)),
+    /**
+     * Invokes the method that executes a double tap on the coordinates provided as a {@link Point}.
+     */
+    GESTURE_DOUBLE_TAP(new RoutingActionArgumentValidator(Point.class)),
+    /**
+     * Invokes the method that executes a pinch in on the coordinates provided as {@link Point Points}.
+     */
+    GESTURE_PINCH_IN(new RoutingActionArgumentValidator(Point.class), new RoutingActionArgumentValidator(Point.class)),
+    /**
+     * Invokes the method that executes a pinch out on the coordinates provided as {@link Point Points}.
+     */
+    GESTURE_PINCH_OUT(new RoutingActionArgumentValidator(Point.class), new RoutingActionArgumentValidator(Point.class)),
+    /**
+     * Invokes the method that executes a swipe on the coordinates provided as a {@link Point}
+     * in the specified direction.
+     */
+    GESTURE_SWIPE(new RoutingActionArgumentValidator(Point.class), new RoutingActionArgumentValidator(SwipeDirection.class)),
+    /**
+     * Invokes the method that executes a drag between the coordinates provided as {@link Point Points}.
+     */
+    GESTURE_DRAG(new RoutingActionArgumentValidator(Point.class), new RoutingActionArgumentValidator(Point.class));
 
     private RoutingActionArgumentValidator[] argumentValidators;
 

--- a/src/main/java/com/musala/atmosphere/commons/RoutingAction.java
+++ b/src/main/java/com/musala/atmosphere/commons/RoutingAction.java
@@ -349,6 +349,10 @@ public enum RoutingAction implements Serializable {
      */
     GET_LAST_TOAST,
     /**
+     * Used to press a device hardware button with the specified ID.
+     */
+    PRESS_HARDWARE_BUTTON(new RoutingActionArgumentValidator(Integer.class)),
+    /**
      * Used to show the tap locations on the current device screen.
      */
     SHOW_TAP_LOCATION(new RoutingActionArgumentValidator(Point.class)),

--- a/src/main/java/com/musala/atmosphere/commons/RoutingAction.java
+++ b/src/main/java/com/musala/atmosphere/commons/RoutingAction.java
@@ -522,7 +522,39 @@ public enum RoutingAction implements Serializable {
     /**
      * Invokes the method that executes a drag between the coordinates provided as {@link Point Points}.
      */
-    GESTURE_DRAG(new RoutingActionArgumentValidator(Point.class), new RoutingActionArgumentValidator(Point.class));
+    GESTURE_DRAG(new RoutingActionArgumentValidator(Point.class), new RoutingActionArgumentValidator(Point.class)),
+    /**
+     * Gets a {@link ScreenOrientation} instance that contains information about the orientation of the screen.
+     */
+    GET_SCREEN_ORIENTATION,
+    /**
+     * Sets a new screen orientation for this device.
+     */
+    SET_SCREEN_ORIENTATION(new RoutingActionArgumentValidator(ScreenOrientation.class)),
+    /**
+     * Gets the auto rotation state of the device.
+     */
+    IS_AUTO_ROTATION_ON,
+    /**
+     * Sets the auto rotation state of the device.
+     */
+    SET_SCREEN_AUTO_ROTATION(new RoutingActionArgumentValidator(Boolean.class)),
+    /**
+     * Gets the airplane mode state of the device.
+     */
+    GET_AIRPLANE_MODE,
+    /**
+     * Sets the airplane mode state of the device.
+     */
+    SET_AIRPLANE_MODE(new RoutingActionArgumentValidator(Boolean.class)),
+    /**
+     * Gets the timeout in the system settings, after which the screen is turned off.
+     */
+    GET_SCREEN_OFF_TIMEOUT,
+    /**
+     * Sets the timeout in the system settings, after which the screen is turned off.
+     */
+    SET_SCREEN_OFF_TIMEOUT(new RoutingActionArgumentValidator(Long.class));
 
     private RoutingActionArgumentValidator[] argumentValidators;
 

--- a/src/main/java/com/musala/atmosphere/commons/RoutingAction.java
+++ b/src/main/java/com/musala/atmosphere/commons/RoutingAction.java
@@ -345,6 +345,14 @@ public enum RoutingAction implements Serializable {
      */
     IS_GPS_LOCATION_ENABLED,
     /**
+     * Used to enable the GPS Location of the device.
+     */
+    ENABLE_GPS_LOCATION,
+    /**
+     * Used to disable the GPS Location of the device.
+     */
+    DISABLE_GPS_LOCATION,
+    /**
      * Used to obtain the text of the last detected toast message.
      */
     GET_LAST_TOAST,

--- a/src/main/java/com/musala/atmosphere/commons/RoutingAction.java
+++ b/src/main/java/com/musala/atmosphere/commons/RoutingAction.java
@@ -468,7 +468,31 @@ public enum RoutingAction implements Serializable {
     /**
      * Gets all web view window handlers that present on the current screen.
      */
-    GET_WEB_VIEWS;
+    GET_WEB_VIEWS,
+    /**
+     * Sends the text that needs to be input and the interval in which it should be input.
+     */
+    IME_INPUT_TEXT(new RoutingActionArgumentValidator(String.class), new RoutingActionArgumentValidator(Long.class)),
+    /**
+     * Used to clear the text from a TextView.
+     */
+    IME_CLEAR_TEXT,
+    /**
+     * Used to select the whole text in a TextView.
+     */
+    IME_SELECT_ALL_TEXT,
+    /**
+     * Used to copy the text from a TextView.
+     */
+    IME_COPY_TEXT,
+    /**
+     * Used to cut the text from a TextView.
+     */
+    IME_CUT_TEXT,
+    /**
+     * Used to paste the text currently in the clipboard into a TextView.
+     */
+    IME_PASTE_TEXT;
 
     private RoutingActionArgumentValidator[] argumentValidators;
 

--- a/src/main/java/com/musala/atmosphere/commons/RoutingAction.java
+++ b/src/main/java/com/musala/atmosphere/commons/RoutingAction.java
@@ -369,7 +369,10 @@ public enum RoutingAction implements Serializable {
      * currently tested.
      */
     GET_WEB_VIEW(new RoutingActionArgumentValidator(String.class)),
-
+    /**
+     * Sets an implicit wait timeout for the web view
+     */
+    SET_WEB_VIEW_IMPLICIT_WAIT(new RoutingActionArgumentValidator(Integer.class)),
     /**
      * Clears the saved data of a given application.
      */


### PR DESCRIPTION
Move the device-related logic from the client to the agent. This way, when a feature for a specific device is added, it is easier to update just the agents instead of all clients.

This pull request should be merged first, because the ones in the agent and client depend on it.
