### PR TITLE
Add an argument to the stop_recording routing action

### DIFF
--- a/src/main/java/com/musala/atmosphere/commons/RoutingAction.java
+++ b/src/main/java/com/musala/atmosphere/commons/RoutingAction.java
@@ -319,7 +319,7 @@ public enum RoutingAction implements Serializable {
     /**
      * Stops recording actions executed on the device.
      */
-    STOP_RECORDING,
+    STOP_RECORDING(new RoutingActionArgumentValidator(String.class)),
     /**
      * Used to open the location settings activity of the device.
      */


### PR DESCRIPTION
The argument specifies the remote directory name where the video record will be uploaded