### PR TITLE
Fix the CONTAINS and WORD_MATCH selection options

### DIFF
--- a/src/main/java/com/musala/atmosphere/commons/ui/selector/UiElementSelector.java
+++ b/src/main/java/com/musala/atmosphere/commons/ui/selector/UiElementSelector.java
@@ -21,6 +21,8 @@ import com.musala.atmosphere.commons.util.Pair;
  *
  */
 public class UiElementSelector implements UiElementPropertiesContainer {
+    private static final long serialVersionUID = 8818379696986115875L;
+
     private static final Logger LOGGER = Logger.getLogger(UiElementSelector.class);
 
     private Map<CssAttribute, Pair<Object, UiElementSelectionOption>> attributeProjectionMap;
@@ -32,7 +34,7 @@ public class UiElementSelector implements UiElementPropertiesContainer {
     /**
      * Constructs ui element selector out of node attribute map.
      *
-     * This is auxiliary constructor needed for some parts of the system. PLease prefer to use
+     * This is auxiliary constructor needed for some parts of the system. Please prefer to use
      * {@link #UiElementSelector()}.
      *
      * @param nodeAttributeMap
@@ -69,23 +71,23 @@ public class UiElementSelector implements UiElementPropertiesContainer {
     }
 
     /**
-     * Adds new selection argument for this ui element selector
+     * Adds a new selection attribute for this UI element selector.
+     * If a value is already set for the provided attribute, it will be replaced.
+     * If the provided value is an empty string, the selection attribute will be ignored.
      * <p>
      * Example usage would be:
      * <p>
      * <code>
-     * uiElementSelector.addSelectionAttribute(SupportedCssAttribute.CHECKABLE, UiElementSelectionOption.EQUALS, true);
+     * uiElementSelector.addSelectionAttribute(CssAttribute.CHECKABLE, UiElementSelectionOption.EQUALS, true);
      * </code>
      *
      * @param attribute
-     *        The attribute for which to add selection expression. If selection expression already existed for the
-     *        attribute it will be replaced.
+     *        - the attribute to add a selection expression for
      * @param selectionOption
-     *        The selection option. One of the {@link UiElementSelectionOption}.
+     *        - the selection option. One of the {@link UiElementSelectionOption}.
      * @param value
-     *        The value to be used in the selection expression. Empty strings will not be added as expressions.
-     * @throws IllegalArgumentException
-     *         In case the supplied value does not match the type of the specified attribute.
+     *        - the value to be used in the selection expression
+     * @throws IllegalArgumentException if the provided value does not match the type of the specified attribute
      */
     public void addSelectionAttribute(CssAttribute attribute, UiElementSelectionOption selectionOption, Object value)
         throws IllegalArgumentException {
@@ -104,48 +106,45 @@ public class UiElementSelector implements UiElementPropertiesContainer {
     }
 
     /**
-     * Adds new selection argument for this ui element selector with selection option that is
-     * {@link UiElementSelectionOption#EQUALS}.
+     * Adds a new selection attribute for this UI element selector with the {@link UiElementSelectionOption#EQUALS}
+     * selection option. If a value is already set for the provided attribute, it will be replaced.
+     * If the provided value is an empty string, the selection attribute will be ignored.
      * <p>
      * Example usage would be:
      * <p>
      * <code>
-     * uiElementSelector.addSelectionAttribute(SupportedCssAttribute.CHECKABLE, true);
+     * uiElementSelector.addSelectionAttribute(CssAttribute.CHECKABLE, true);
      * </code>
      *
      * @param attribute
-     *        The attribute for which to add selection expression. If selection expression already existed for the
-     *        attribute it will be replaced.
+     *        - the attribute to add a selection expression for
      * @param value
-     *        The value to be used in the selection expression. Empty strings will not be added as expressions.
-     * @throws IllegalArgumentException
-     *         In case the supplied value does not match the type of the specified attribute.
+     *        - the value to be used in the selection expression
+     * @throws IllegalArgumentException if the provided value does not match the type of the specified attribute
      */
     public void addSelectionAttribute(CssAttribute attribute, Object value) {
         addSelectionAttribute(attribute, UiElementSelectionOption.EQUALS, value);
     }
 
     /**
-     * Use the method to get the value of boolean attribute selection argument
+     * Returns the value of a boolean {@link CssAttribute}.
      *
      * @param attribute
-     *        The attribute for which to get the selection argument
-     * @return The boolean value or null if no selection was specified.
-     * @throws IllegalArgumentException
-     *         If the attribute selection requested is not for boolean attribute.
+     *        - the boolean attribute to get the value of
+     * @return the boolean attribute's value or <code>null</code> if no value is set for this attribute
+     * @throws IllegalArgumentException if the provided attribute is not a boolean attribute
      */
     public Boolean getBooleanValue(CssAttribute attribute) {
         return (Boolean) getGenericValue(attribute, Boolean.class);
     }
 
     /**
-     * Use the method to get the value of string attribute selection argument
+     * Returns the value of a string {@link CssAttribute}.
      *
      * @param attribute
-     *        The attribute for which to get the selection argument
-     * @return The string value or null if no selection was specified.
-     * @throws IllegalArgumentException
-     *         If the attribute selection requested is not for string attribute.
+     *        - the string attribute to get the value of
+     * @return the string attribute's value or <code>null</code> if no value is set for this attribute
+     * @throws IllegalArgumentException if the provided attribute is not a string attribute
      */
     public String getStringValue(CssAttribute attribute) {
         return (String) getGenericValue(attribute, String.class);
@@ -158,8 +157,7 @@ public class UiElementSelector implements UiElementPropertiesContainer {
      *        - the string attribute to get the value of
      * @return a {@link Pair} of the attribute's value and its selection option, or <code>null</code>
      *         if the value or the selection option is <code>null</code>
-     * @throws IllegalArgumentException
-     *         if the provided attribute is not a string attribute
+     * @throws IllegalArgumentException if the provided attribute is not a string attribute
      */
     public Pair<String, UiElementSelectionOption> getStringValueWithSelectionOption(CssAttribute attribute) {
         String stringValue = getStringValue(attribute);
@@ -173,26 +171,24 @@ public class UiElementSelector implements UiElementPropertiesContainer {
     }
 
     /**
-     * Use the method to get the value of integer attribute selection argument
+     * Returns the value of an integer {@link CssAttribute}.
      *
      * @param attribute
-     *        The attribute for which to get the selection argument
-     * @return The integer value or null if no selection was specified.
-     * @throws IllegalArgumentException
-     *         If the attribute selection requested is not for integer attribute.
+     *        - the integer attribute to get the value of
+     * @return the integer attribute's value or <code>null</code> if no value is set for this attribute
+     * @throws IllegalArgumentException if the provided attribute is not an integer attribute
      */
     public Integer getIntegerValue(CssAttribute attribute) {
         return (Integer) getGenericValue(attribute, Integer.class);
     }
 
     /**
-     * Use the method to get the value of {@link Bounds} attribute selection argument
+     * Returns the value of a {@link Bounds} {@link CssAttribute}.
      *
      * @param attribute
-     *        The attribute for which to get the selection argument
-     * @return The {@link Bounds} value or null if no selection was specified.
-     * @throws IllegalArgumentException
-     *         If the attribute selection requested is not for {@link Bounds} attribute.
+     *        - the {@link CssAttribute#BOUNDS} attribute to get the value of
+     * @return the {@link Bounds} attribute's value or <code>null</code> if no value is set for this attribute
+     * @throws IllegalArgumentException if the provided attribute is not of type {@link CssAttribute#BOUNDS}
      */
     public Bounds getBoundsValue(CssAttribute attribute) {
         return (Bounds) getGenericValue(attribute, Bounds.class);
@@ -201,7 +197,7 @@ public class UiElementSelector implements UiElementPropertiesContainer {
     /**
      * Builds a CSS select element query based on the contents of this selector.
      *
-     * @return the built CSS query.
+     * @return the built CSS query
      */
     public String buildCssQuery() {
         StringBuilder builder = new StringBuilder();

--- a/src/main/java/com/musala/atmosphere/commons/ui/selector/UiElementSelector.java
+++ b/src/main/java/com/musala/atmosphere/commons/ui/selector/UiElementSelector.java
@@ -16,9 +16,9 @@ import com.musala.atmosphere.commons.util.Pair;
 
 /**
  * Selector class for screen UI elements, used to search for a specific element with given attributes.
- * 
+ *
  * @author georgi.gaydarov
- * 
+ *
  */
 public class UiElementSelector implements UiElementPropertiesContainer {
     private static final Logger LOGGER = Logger.getLogger(UiElementSelector.class);
@@ -31,10 +31,10 @@ public class UiElementSelector implements UiElementPropertiesContainer {
 
     /**
      * Constructs ui element selector out of node attribute map.
-     * 
+     *
      * This is auxiliary constructor needed for some parts of the system. PLease prefer to use
      * {@link #UiElementSelector()}.
-     * 
+     *
      * @param nodeAttributeMap
      *        a map between the html attribute names and their corresponding values
      * @throws IllegalArgumentException
@@ -76,7 +76,7 @@ public class UiElementSelector implements UiElementPropertiesContainer {
      * <code>
      * uiElementSelector.addSelectionAttribute(SupportedCssAttribute.CHECKABLE, UiElementSelectionOption.EQUALS, true);
      * </code>
-     * 
+     *
      * @param attribute
      *        The attribute for which to add selection expression. If selection expression already existed for the
      *        attribute it will be replaced.
@@ -112,7 +112,7 @@ public class UiElementSelector implements UiElementPropertiesContainer {
      * <code>
      * uiElementSelector.addSelectionAttribute(SupportedCssAttribute.CHECKABLE, true);
      * </code>
-     * 
+     *
      * @param attribute
      *        The attribute for which to add selection expression. If selection expression already existed for the
      *        attribute it will be replaced.
@@ -127,7 +127,7 @@ public class UiElementSelector implements UiElementPropertiesContainer {
 
     /**
      * Use the method to get the value of boolean attribute selection argument
-     * 
+     *
      * @param attribute
      *        The attribute for which to get the selection argument
      * @return The boolean value or null if no selection was specified.
@@ -140,7 +140,7 @@ public class UiElementSelector implements UiElementPropertiesContainer {
 
     /**
      * Use the method to get the value of string attribute selection argument
-     * 
+     *
      * @param attribute
      *        The attribute for which to get the selection argument
      * @return The string value or null if no selection was specified.
@@ -152,8 +152,29 @@ public class UiElementSelector implements UiElementPropertiesContainer {
     }
 
     /**
+     * Returns a {@link Pair} of the value of a string {@link CssAttribute} and its {@link UiElementSelectionOption} option.
+     *
+     * @param attribute
+     *        - the string attribute to get the value of
+     * @return a {@link Pair} of the attribute's value and its selection option, or <code>null</code>
+     *         if the value or the selection option is <code>null</code>
+     * @throws IllegalArgumentException
+     *         if the provided attribute is not a string attribute
+     */
+    public Pair<String, UiElementSelectionOption> getStringValueWithSelectionOption(CssAttribute attribute) {
+        String stringValue = getStringValue(attribute);
+        UiElementSelectionOption selectionOption = getUiElementSelectionOption(attribute);
+
+        if (stringValue == null || selectionOption == null) {
+            return null;
+        }
+
+        return new Pair<String, UiElementSelectionOption>(stringValue, selectionOption);
+    }
+
+    /**
      * Use the method to get the value of integer attribute selection argument
-     * 
+     *
      * @param attribute
      *        The attribute for which to get the selection argument
      * @return The integer value or null if no selection was specified.
@@ -166,7 +187,7 @@ public class UiElementSelector implements UiElementPropertiesContainer {
 
     /**
      * Use the method to get the value of {@link Bounds} attribute selection argument
-     * 
+     *
      * @param attribute
      *        The attribute for which to get the selection argument
      * @return The {@link Bounds} value or null if no selection was specified.
@@ -179,7 +200,7 @@ public class UiElementSelector implements UiElementPropertiesContainer {
 
     /**
      * Builds a CSS select element query based on the contents of this selector.
-     * 
+     *
      * @return the built CSS query.
      */
     public String buildCssQuery() {
@@ -211,6 +232,14 @@ public class UiElementSelector implements UiElementPropertiesContainer {
         } else {
             throw new IllegalArgumentException("Trying to get boolean value of non-boolean attribute " + attribute);
         }
+    }
+
+    private UiElementSelectionOption getUiElementSelectionOption(CssAttribute attribute) {
+        if (!attributeProjectionMap.containsKey(attribute)) {
+            return null;
+        }
+
+        return attributeProjectionMap.get(attribute).getValue();
     }
 
     private Object determineAttributeValue(CssAttribute cssAttribute, String value) {

--- a/src/main/java/com/musala/atmosphere/commons/ui/tree/matcher/UiElementSelectorMatcherCompat.java
+++ b/src/main/java/com/musala/atmosphere/commons/ui/tree/matcher/UiElementSelectorMatcherCompat.java
@@ -3,7 +3,9 @@ package com.musala.atmosphere.commons.ui.tree.matcher;
 import com.musala.atmosphere.commons.geometry.Bounds;
 import com.musala.atmosphere.commons.geometry.Point;
 import com.musala.atmosphere.commons.ui.selector.CssAttribute;
+import com.musala.atmosphere.commons.ui.selector.UiElementSelectionOption;
 import com.musala.atmosphere.commons.ui.selector.UiElementSelector;
+import com.musala.atmosphere.commons.util.Pair;
 
 import android.graphics.Rect;
 import android.view.accessibility.AccessibilityNodeInfo;
@@ -22,10 +24,10 @@ public class UiElementSelectorMatcherCompat implements UiElementMatcher<UiElemen
     public boolean match(UiElementSelector selector, AccessibilityNodeInfo nodeInformation) {
         // TODO Improve the logic for matching components
         Bounds selectorBounds = selector.getBoundsValue(CssAttribute.BOUNDS);
-        String selectorClass = selector.getStringValue(CssAttribute.CLASS_NAME);
-        String selectorPackage = selector.getStringValue(CssAttribute.PACKAGE_NAME);
-        String selectorText = selector.getStringValue(CssAttribute.TEXT);
-        String selectorDescription = selector.getStringValue(CssAttribute.CONTENT_DESCRIPTION);
+        Pair<String, UiElementSelectionOption> selectorClass = selector.getStringValueWithSelectionOption(CssAttribute.CLASS_NAME);
+        Pair<String, UiElementSelectionOption> selectorPackage = selector.getStringValueWithSelectionOption(CssAttribute.PACKAGE_NAME);
+        Pair<String, UiElementSelectionOption> selectorText = selector.getStringValueWithSelectionOption(CssAttribute.TEXT);
+        Pair<String, UiElementSelectionOption> selectorDescription = selector.getStringValueWithSelectionOption(CssAttribute.CONTENT_DESCRIPTION);
         Boolean isClickable = selector.getBooleanValue(CssAttribute.CLICKABLE);
         Boolean isCheckable = selector.getBooleanValue(CssAttribute.CHECKABLE);
         Boolean isChecked = selector.getBooleanValue(CssAttribute.CHECKED);
@@ -50,24 +52,27 @@ public class UiElementSelectorMatcherCompat implements UiElementMatcher<UiElemen
             }
         }
 
-        if (selectorClass != null && nodeInformation.getClassName() != null
-                && !selectorClass.equals(nodeInformation.getClassName().toString())) {
+        String nodeClassName = nodeInformation.getClassName() != null
+                ? nodeInformation.getClassName().toString() : null;
+        if (selectorClass != null && nodeClassName != null && !isMatch(selectorClass, nodeClassName)) {
             return false;
         }
 
-        if (selectorPackage != null && nodeInformation.getPackageName() != null
-                && !selectorPackage.equals(nodeInformation.getPackageName().toString())) {
+        String nodePackageName = nodeInformation.getPackageName() != null
+                ? nodeInformation.getPackageName().toString() : null;
+        if (selectorPackage != null && nodePackageName != null && !isMatch(selectorPackage, nodePackageName)) {
             return false;
         }
 
         String nodeContentDescription = nodeInformation.getContentDescription() != null
                 ? nodeInformation.getContentDescription().toString() : null;
-        if (selectorDescription != null && !selectorDescription.equals(nodeContentDescription)) {
+        if (selectorDescription != null && !isMatch(selectorDescription, nodeContentDescription)) {
             return false;
         }
 
+
         String nodeText = nodeInformation.getText() != null ? nodeInformation.getText().toString() : null;
-        if (selectorText != null && !selectorText.equals(nodeText)) {
+        if (selectorText != null && !isMatch(selectorText, nodeText)) {
             return false;
         }
 
@@ -112,5 +117,21 @@ public class UiElementSelectorMatcherCompat implements UiElementMatcher<UiElemen
         }
 
         return true;
+    }
+
+    private boolean isMatch(Pair<String, UiElementSelectionOption> selectorPair, String nodeValue) {
+        if (nodeValue == null) {
+            return false;
+        }
+        switch (selectorPair.getValue()) {
+            case CONTAINS:
+                return nodeValue.contains(selectorPair.getKey());
+            case EQUALS:
+                return nodeValue.equals(selectorPair.getKey());
+            case WORD_MATCH:
+                return nodeValue.matches(selectorPair.getKey());
+            default:
+                return nodeValue.equals(selectorPair.getKey());
+        }
     }
 }


### PR DESCRIPTION
Fix the `CONTAINS` and `WORD_MATCH` UiElementSelectionOptions.
Update the UiElementSelector javadoc according to the style guide and improve readability.
See MusalaSoft/atmosphere-docs#56